### PR TITLE
Config fix for Model

### DIFF
--- a/conf/conf_training_example_baskerville.yaml
+++ b/conf/conf_training_example_baskerville.yaml
@@ -21,7 +21,7 @@ database:
 engine:
   storage_path: !ENV '${BASKERVILLE_ROOT}/data/'
   training:                           # Optional: only for the Training pipeline
-    model: 'AnomalyModel' # which model to use, see baskerville.util.enums.ModelEnum
+    model: 'baskerville.models.anomaly_model.AnomalyModel' # which model to use, see baskerville.util.enums.ModelEnum
     data_parameters:                  # to define the training period, either use training_days or from/ to date
 #      training_days: 30               # today - training_days
       from_date: '2020-03-01 20:59:59'

--- a/src/baskerville/models/config.py
+++ b/src/baskerville/models/config.py
@@ -461,7 +461,7 @@ class TrainingConfig(Config):
 
     def __init__(self, config, parent=None):
         super(TrainingConfig, self).__init__(config, parent)
-        self.allowed_models = [e.name for e in ModelEnum]
+        self.allowed_models = [e.value for e in ModelEnum]
 
     def validate(self):
         logger.debug('Validating TrainingConfig...')

--- a/src/baskerville/models/pipeline_training.py
+++ b/src/baskerville/models/pipeline_training.py
@@ -85,7 +85,7 @@ class TrainingPipeline(PipelineBase):
         :return:
         """
         self.spark = get_or_create_spark_session(self.spark_conf)
-        self.model = instantiate_from_str(ModelEnum[self.training_conf.model].value)
+        self.model = instantiate_from_str(self.training_conf.model)
         self.model.set_params(**self.engine_conf.training.model_parameters)
 
         conf = self.db_conf

--- a/src/baskerville/models/pipeline_training.py
+++ b/src/baskerville/models/pipeline_training.py
@@ -13,7 +13,7 @@ import pyspark
 from baskerville.models.config import EngineConfig, DatabaseConfig, SparkConfig
 from baskerville.spark import get_or_create_spark_session
 from baskerville.spark.helpers import reset_spark_storage
-from baskerville.util.enums import Step, ModelEnum
+from baskerville.util.enums import Step
 from baskerville.util.helpers import instantiate_from_str, get_model_path
 from baskerville.db.models import Model
 


### PR DESCRIPTION
Rollback of the config change in model_path PR. Now, as before, `engine.training.model` refers to the full module path of the Model class(not the Enum key).