### PR TITLE
first swing at turning banjax's kafka messages into prometheus metrics

### DIFF
--- a/conf/conf_example_baskerville.yaml
+++ b/conf/conf_example_baskerville.yaml
@@ -142,3 +142,13 @@ spark:
   # number of ParallelGCThreads cannot go above the number of cores
   # ConcGCThreads=2 : two per core is a reasonable option that works well on most cases
   # InitiatingHeapOccupancyPercent=25: allocate 25% for heap - this has to be tested on your machine to see which percentage works well
+
+kafka:
+  bootstrap_servers: '127.0.0.1:9092'
+  banjax_report_topic: 'banjax_report_topic'
+  banjax_command_topic: 'banjax_command_topic'
+  security_protocol: 'SSL'
+  ssl_check_hostname: False
+  ssl_cafile: '~/code/equalitie/baskerville/caroot.pem'
+  ssl_certfile: '~/code/equalitie/baskerville/certificate.pem'
+  ssl_keyfile: '~/code/equalitie/baskerville/key.pem'

--- a/data/metrics/Banjax-Dashboard.json
+++ b/data/metrics/Banjax-Dashboard.json
@@ -1,0 +1,825 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 8,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "baskerville_proxy_process_net_connections_currently_open",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "baskerville_proxy_process_net_connections_currently_open",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "baskerville_num_of_challenges",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Active challenges per Banjax instance",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "baskerville_proxy_process_cache_ram_cache_total_bytes",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "baskerville_proxy_process_cache_ram_cache_total_bytes",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "baskerville_proxy_process_http_current_active_client_connections",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "baskerville_proxy_process_http_current_active_client_connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "baskerville_proxy_process_cache_ram_cache_bytes_used",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "baskerville_proxy_process_cache_ram_cache_bytes_used",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "baskerville_proxy_process_cache_percent_full",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "baskerville_proxy_process_cache_percent_full",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 8,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "baskerville_proxy_process_cache_bytes_total",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "baskerville_proxy_process_cache_bytes_total",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "baskerville_ip_failed_challenge_on_website_total",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Num of IPs that failed challenger",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "baskerville_proxy_process_traffic_server_memory_rss",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "memory usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 21,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Banjax Dashboard",
+  "uid": "_97RizZGk",
+  "version": 6
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ isoweek==1.3.3
 plotly==4.5.0
 pdoc==0.3.2
 markdown>=3.0
+kafka-python==2.0.1

--- a/requirements_unit_tests.txt
+++ b/requirements_unit_tests.txt
@@ -33,3 +33,4 @@ prometheus_client==0.5.0
 isoweek==1.3.3
 pdoc==0.3.2
 spark-testing-base
+kafka-python==2.0.1

--- a/src/baskerville/models/config.py
+++ b/src/baskerville/models/config.py
@@ -702,6 +702,10 @@ class KafkaConfig(Config):
     ssl_keystore_password = ''
     ssl_key_password = ''
     ssl_endpoint_identification_algorithm = ''
+    ssl_check_hostname = ''
+    ssl_cafile = ''
+    ssl_certfile = ''
+    ssl_keyfile = ''
 
     def __init__(self, config):
         super(KafkaConfig, self).__init__(config)

--- a/src/baskerville/models/engine.py
+++ b/src/baskerville/models/engine.py
@@ -255,7 +255,7 @@ class BaskervilleAnalyticsEngine(BaskervilleBase):
         """
         self.pipeline = self._set_up_pipeline()
         self.pipeline.initialize()
-        self.status_consumer = StatusConsumer(self.config, self.logger)
+        self.status_consumer = StatusConsumer(self.config.kafka, self.logger)
         t1 = threading.Thread(target=self.status_consumer.run)
         t1.start()
         self._register_metrics()

--- a/src/baskerville/models/metrics/helpers.py
+++ b/src/baskerville/models/metrics/helpers.py
@@ -50,6 +50,7 @@ def set__self__(fn):
     def wrapped_f(self, func_to_watch_for, *args, **kwargs):
         if not has_self(func_to_watch_for):
             if not is_wrapped_method(func_to_watch_for):
+                print(f'{func_to_watch_for.__name__} is not a bound method -')
                 raise ValueError(
                     f'{func_to_watch_for.__name__} is not a bound method -'
                     f'currently unsupported.'
@@ -61,7 +62,7 @@ def set__self__(fn):
     return wrapped_f
 
 
-def update_avg_hosts_counter(metric, self):
+def update_avg_hosts_counter(metric, self, result):
     """
     Averages the host predictions and increments the metric by labels
     :param metric:
@@ -77,7 +78,7 @@ def update_avg_hosts_counter(metric, self):
             metric.labels(k).set(v1[k])
 
 
-def incr_counter_for_logs_df(metric, self):
+def incr_counter_for_logs_df(metric, self, result):
     """
     Increment by the number of requests / request sets
     :param metric:
@@ -87,7 +88,7 @@ def incr_counter_for_logs_df(metric, self):
     metric.inc(self.logs_df.count())
 
 
-def set_counter_for_logs_df(metric, self):
+def set_counter_for_logs_df(metric, self, result):
     """
     Increment by the number of requests / request sets
     :param metric:

--- a/src/baskerville/models/metrics/registry.py
+++ b/src/baskerville/models/metrics/registry.py
@@ -146,7 +146,7 @@ class MetricsRegistry(Singleton):
         def wrapper_f(*args, **kwargs):
             result = fn(*args, **kwargs)
             stats_h = self.registry[metric_name]
-            stats_h.hooks_to_callbacks['after'](stats_h.metric, fn.__self__)
+            stats_h.hooks_to_callbacks['after'](stats_h.metric, fn.__self__, result)
             return result
 
         # restore __self__ because wrapping loses it.

--- a/src/baskerville/models/status_consumer.py
+++ b/src/baskerville/models/status_consumer.py
@@ -14,7 +14,13 @@ from baskerville import src_dir
 
 class StatusConsumer(object):
     status_message_fields = [
+        "timestamp",
+        "restart_time",
+        "reload_time",
         "num_of_challenges",
+        "swabber_ip_db_size",
+        "regex_manager_ip_db_size",
+        "challenger_ip_db_size",
         "proxy.process.traffic_server.memory.rss",
         "proxy.node.cache.contents.num_docs",
         "proxy.process.cache.bytes_total",

--- a/src/baskerville/models/status_consumer.py
+++ b/src/baskerville/models/status_consumer.py
@@ -1,0 +1,157 @@
+import threading
+import json
+from kafka import KafkaConsumer, KafkaProducer
+import time
+import logging
+import sys
+import types
+from baskerville.models.config import KafkaConfig
+from baskerville.util.helpers import parse_config
+import argparse
+import os
+from baskerville import src_dir
+
+
+class StatusConsumer(object):
+    status_message_fields = [
+        "num_of_challenges",
+        "proxy.process.traffic_server.memory.rss",
+        "proxy.node.cache.contents.num_docs",
+        "proxy.process.cache.bytes_total",
+        "proxy.process.cache.percent_full",
+        "proxy.process.cache.ram_cache.bytes_used",
+        "proxy.process.cache.ram_cache.total_bytes",
+        "proxy.process.net.connections_currently_open",
+        "proxy.process.current_server_connections",
+        "proxy.process.http.current_active_client_connections",
+        "proxy.process.eventloop.time.max"
+    ]
+
+    def __init__(self, config, logger):
+        self.config = config
+        self.logger = logger
+
+        # XXX i think the metrics registry swizzling code is passing
+        # an extra argument here mistakenly?.?.
+        def _tmp_fun(_, _2, message):
+            return message
+
+        for field_name in self.__class__.status_message_fields:
+            setattr(self, f"consume_{field_name}", types.MethodType(_tmp_fun, self))
+
+    def run(self):
+        consumer = KafkaConsumer(
+            self.config.kafka.get('banjax_report_topic'),
+            bootstrap_servers=self.config.kafka.get('bootstrap_servers'),
+            security_protocol=self.config.kafka.get('security_protocol'),
+            ssl_check_hostname=self.config.kafka.get('ssl_check_hostname'),
+            ssl_cafile=self.config.kafka.get('ssl_cafile'),
+            ssl_certfile=self.config.kafka.get('ssl_certfile'),
+            ssl_keyfile=self.config.kafka.get('ssl_keyfile'),
+        )
+
+        for message in consumer:
+            self.consume_message(message)
+
+        consumer.close()
+
+    def consume_message(self, message):
+        if len(message.value) > 0:
+            try:
+                s = message.value.decode("utf-8")
+            except UnicodeDecodeError:
+                self.logger.info("got bad utf-8 over the kafka channel")
+
+            try:
+                d = json.loads(s)
+            except json.JSONDecodeError:
+                self.logger.info(f"got bad json over the kafka channel: {s}")
+
+            self.logger.info(f"got a message: {d}")
+
+            # 'status'-type messages contain several metrics and are reported per $interval
+            if d.get("name") == "status":
+                for k, _ in d.items():
+                    try:
+                        self.logger.info(f"try to dispatch on {k}")
+                        f = getattr(self, f"consume_{k}")
+                        f(self, d)
+                        self.logger.info(f"dispatched {k}")
+                    except AttributeError:
+                        self.logger.info(f"did not dispatch {k}")
+
+            # 'ip_failed_challenge'-type messages are reported when a challenge is failed
+            elif d.get("name") == "ip_failed_challenge":
+                self.consume_ip_failed_challenge_message(d)
+
+    def consume_ip_failed_challenge_message(self, message):
+        return message
+
+
+class ChallengeProducer(object):
+    def __init__(self, config, logger):
+        self.config = config
+        self.logger = logger
+
+    def run(self):
+        producer = KafkaProducer(
+            bootstrap_servers=self.config.kafka.get('bootstrap_servers'),
+            security_protocol=self.config.kafka.get('security_protocol'),
+            ssl_check_hostname=self.config.kafka.get('ssl_check_hostname'),
+            ssl_cafile=self.config.kafka.get('ssl_cafile'),
+            ssl_certfile=self.config.kafka.get('ssl_certfile'),
+            ssl_keyfile=self.config.kafka.get('ssl_keyfile'),
+        )
+
+        number = 0
+        while True:
+            for _ in range(0, 10):
+                domain = f"example-{number}.com:8080"
+                command = {'name': 'challenge_host', 'value': domain}
+                producer.send(self.config.kafka.get('banjax_command_topic'), json.dumps(command).encode('utf-8'))
+                self.logger.info("sent a command")
+                number = number + 1
+            time.sleep(0.1)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--conf", action="store", dest="conf_file",
+        default=os.path.join(src_dir, '..', 'conf', 'baskerville.yaml'),
+        help="Path to config file"
+    )
+
+    parser.add_argument(
+        "-c", "--consumer", dest="start_consumer", action="store_true",
+        help="start consumer",
+    )
+
+    parser.add_argument(
+        "-p", "--producer", dest="start_producer", action="store_true",
+        help="start consumer",
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+    logger = logging.getLogger()
+
+    config = KafkaConfig(parse_config(path=args.conf_file)).validate()
+
+    if args.start_consumer:
+        status_consumer = StatusConsumer(config, logger)
+        consumer_thread = threading.Thread(target=status_consumer.run)
+        consumer_thread.start()
+
+    if args.start_producer:
+        challenge_producer = ChallengeProducer(config, logger)
+        producer_thread = threading.Thread(target=challenge_producer.run)
+        producer_thread.start()
+
+    if args.start_consumer:
+        consumer_thread.join()
+
+    if args.start_producer:
+        producer_thread.join()

--- a/src/baskerville/models/status_consumer.py
+++ b/src/baskerville/models/status_consumer.py
@@ -42,6 +42,7 @@ class StatusConsumer(object):
     def run(self):
         consumer = KafkaConsumer(
             self.config.banjax_report_topic,
+            group_id="some_random_thing",
             bootstrap_servers=self.config.bootstrap_servers,
             security_protocol=self.config.security_protocol,
             ssl_check_hostname=self.config.ssl_check_hostname,
@@ -108,10 +109,10 @@ class ChallengeProducer(object):
             for _ in range(0, 10):
                 domain = f"example-{number}.com:8080"
                 command = {'name': 'challenge_host', 'value': domain}
-                producer.send(self.config.get('banjax_command_topic'), json.dumps(command).encode('utf-8'))
+                producer.send(self.config.banjax_command_topic, json.dumps(command).encode('utf-8'))
                 self.logger.info("sent a command")
                 number = number + 1
-            time.sleep(0.1)
+            time.sleep(1)
 
 
 if __name__ == '__main__':
@@ -138,7 +139,7 @@ if __name__ == '__main__':
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
     logger = logging.getLogger()
 
-    config_dict = KafkaConfig(parse_config(path=args.conf_file)).validate()
+    config_dict = KafkaConfig(parse_config(path=args.conf_file)['kafka']).validate()
 
     if args.start_consumer:
         status_consumer = StatusConsumer(config_dict, logger)

--- a/tests/unit/baskerville_tests/models_tests/metrics_tests/test_registry.py
+++ b/tests/unit/baskerville_tests/models_tests/metrics_tests/test_registry.py
@@ -113,7 +113,7 @@ class TestMetricsRegistry(unittest.TestCase):
         mr.registry[name] = StatsHook(
             metric=mock_metric,
             wrapped_func_name=name,
-            hooks_to_callbacks={'after': lambda m, s: print(m, s)}
+            hooks_to_callbacks={'after': lambda m, s, r: print(m, s, r)}
         )
 
         wrapped_fn = mr.after_wrapper(test_fn, name)


### PR DESCRIPTION
There's probably a better way to skin this cat. Right now I have some methods in StatusConsumer which appear to do nothing but which are rebound with extra features from a distance. There's probably a more intentional-looking way to say in one place "here's a list of messages we'd like to receive and the prometheus metrics that should be made from them." To discuss tomorrow.