### PR TITLE
Fix rs cache issue

### DIFF
--- a/src/baskerville/models/pipeline_tasks/client_pipeline.py
+++ b/src/baskerville/models/pipeline_tasks/client_pipeline.py
@@ -7,9 +7,10 @@
 
 from baskerville.models.pipeline_tasks.tasks_base import Task
 from baskerville.models.config import BaskervilleConfig
-from baskerville.models.pipeline_tasks.tasks import GetDataKafka, GenerateFeatures, \
+from baskerville.models.pipeline_tasks.tasks import GetDataKafka, \
+    GenerateFeatures, \
     Save, CacheSensitiveData, SendToKafka, \
-    GetPredictions, MergeWithSensitiveData
+    GetPredictions, MergeWithSensitiveData, RefreshCache
 
 
 def set_up_preprocessing_pipeline(config: BaskervilleConfig):
@@ -24,6 +25,7 @@ def set_up_preprocessing_pipeline(config: BaskervilleConfig):
                     columns=('id_client', 'id_group', 'features'),
                     topic=config.kafka.features_topic,
                 ),
+                RefreshCache(config)
             ]),
     ]
 

--- a/src/baskerville/models/pipeline_tasks/kafka_pipeline.py
+++ b/src/baskerville/models/pipeline_tasks/kafka_pipeline.py
@@ -8,7 +8,7 @@
 from baskerville.models.pipeline_tasks.tasks_base import Task
 from baskerville.models.config import BaskervilleConfig
 from baskerville.models.pipeline_tasks.tasks import GenerateFeatures, \
-    Save, Predict, GetDataKafka
+    Save, Predict, GetDataKafka, RefreshCache
 
 
 def set_up_isac_kafka_pipeline(config: BaskervilleConfig):
@@ -19,6 +19,7 @@ def set_up_isac_kafka_pipeline(config: BaskervilleConfig):
                 GenerateFeatures(config),
                 Predict(config),
                 Save(config),
+                RefreshCache(config),
             ]),
     ]
 

--- a/src/baskerville/models/pipeline_tasks/rawlog_pipeline.py
+++ b/src/baskerville/models/pipeline_tasks/rawlog_pipeline.py
@@ -9,7 +9,7 @@ from baskerville.models.pipeline_tasks.tasks_base import Task
 from baskerville.models.config import BaskervilleConfig
 from baskerville.models.pipeline_tasks.tasks import GenerateFeatures, \
     Save, \
-    Predict, GetDataLog
+    Predict, GetDataLog, RefreshCache
 
 
 def set_up_isac_rawlog_pipeline(config: BaskervilleConfig):
@@ -20,6 +20,7 @@ def set_up_isac_rawlog_pipeline(config: BaskervilleConfig):
                 GenerateFeatures(config),
                 Predict(config),
                 Save(config),
+                RefreshCache(config),
             ]),
     ]
 

--- a/src/baskerville/models/pipeline_tasks/tasks.py
+++ b/src/baskerville/models/pipeline_tasks/tasks.py
@@ -936,11 +936,8 @@ class Save(SaveDfInPostgres):
         self.df = self.df.select(request_set_columns)
         self.df = self.df.withColumn(
             'created_at',
-            F.unix_timestamp(
-                F.current_timestamp(),
-                format="YYYY-MM-DD %H:%M:%S")
+            F.current_timestamp()
         )
-        self.df.show()
 
     def run(self):
         self.prepare_to_save()


### PR DESCRIPTION
So, it turns out that the request set refresh was not in the correct place now or before (`Save` task was missing the `CacheTask` base so it worked out of luck), because we need to filter out the columns we don't need and one of them is `score` which happens after the feature generation task. It also doesn't make sense to refresh the cache if we are not 100% sure that we have saved the df data. Otherwise we might have inconsistencies.
This is why I created a task: `RefreshCache` and it is being called after `Save` or `SendToKafka`. 

Additionally, I added a `created_at` fix to save the current UTC timestamp. It works as expected, creates a now timestamp and since the spark session is in UTC, the timestamp is in UTC too. When it gets saved in the table, it also gets the tz information, which is `+00`. We should have a correct `created_at` as we discussed and partition by stop. (I will be testing the Timescaledb stuff we said today or tomorrow)

Please, take a look and tell me what you think :)