### PR TITLE
Configurable option for kafka sending

### DIFF
--- a/src/baskerville/models/config.py
+++ b/src/baskerville/models/config.py
@@ -284,6 +284,7 @@ class EngineConfig(Config):
     origin_ips_refresh_period_in_seconds = 300
     url_origin_ips = ''
     new_model_check_in_seconds = 300
+    kafka_send_by_partition = True
 
     def __init__(self, config, parent=None):
         super(EngineConfig, self).__init__(config, parent)


### PR DESCRIPTION
New engine config parameter `kafka_send_by_partition`.
If True, use send_by_partition function for sending to Kafka topic.
If False, use collect().