### PR TITLE
Request ID fix

### DIFF
--- a/src/baskerville/models/pipeline_tasks/tasks.py
+++ b/src/baskerville/models/pipeline_tasks/tasks.py
@@ -816,7 +816,7 @@ class GenerateFeatures(MLTask):
                 '_',
                 F.col('id_client'),
                 F.col('id_request_sets'),
-                F.col('start').cast('long').cast('string'))
+                F.col('stop').cast('long').cast('string'))
         )
         # todo: monotonically_increasing_id guarantees uniqueness within
         #  the current batch, this will cause conflicts with caching - use


### PR DESCRIPTION
Using stop instead of start in create_ids to avoid potential conflicts.