### PR TITLE
Incident detector fix. 

### DIFF
--- a/src/baskerville/db/models.py
+++ b/src/baskerville/db/models.py
@@ -99,6 +99,8 @@ class RequestSet(Base, SerializableMixin):
     id_banjax = Column(Integer, ForeignKey('banjax_bans.id'), nullable=True)
     process_flag = Column(Boolean, default=True)
     prediction = Column(Integer)
+    prediction_anomaly = Column(Integer)
+    prediction_classifier = Column(Integer)
     attack_prediction = Column(Integer)
     challenged = Column(Integer)
     challenge_failed = Column(Integer)
@@ -147,6 +149,8 @@ class RequestSet(Base, SerializableMixin):
         'start',
         'stop',
         'prediction',
+        'prediction_anomaly',
+        'prediction_classifier',
         'attack_prediction',
         'low_rate_attack',
         'challenged',

--- a/src/baskerville/spark/helpers.py
+++ b/src/baskerville/spark/helpers.py
@@ -294,7 +294,7 @@ def get_window(df, time_bucket: TimeBucket, storage_level: str, logger):
 
 
 def df_has_rows(df):
-    return df and df.head(1)
+    return df and not df.rdd.isEmpty()
 
 
 def get_dtype_for_col(df, col):

--- a/tests/unit/baskerville_tests/models_tests/test_base_spark.py
+++ b/tests/unit/baskerville_tests/models_tests/test_base_spark.py
@@ -684,6 +684,8 @@ class TestSparkPipelineBase(SQLTestCaseLatestSpark):
                 'id_runtime': -1,
                 'request_set_prediction': -1,
                 'prediction': -1,
+                'prediction_anomaly': 0,
+                'prediction_classifier': 0,
                 'attack_prediction': 0,
                 'low_rate_attack': 0,
                 'challenged': 0,


### PR DESCRIPTION
Now the detection completely relies on anomaly score rather than on both anomaly and classifier score. The reason is that classifier is biased toward historical incidents and is not good at detecting previously unseen patterns.